### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These are my QEMU configurations for a Windows 10 VM on libvirt. Emphasis is given on performance and satisfying requirements for my workplace IT security.
 
-Benchmark results using Phoronix are found in the root directory.
+Bare metal benchmark results using Phoronix are found in the root directory.
 
 ## To use
 
@@ -23,3 +23,14 @@ You probably also want `virt-manager`, which includes a spice compatible viewer.
 
 At this point you can start the VM with `virt-manager` or `virsh` directly.
 
+
+### Current benchmarks
+
+Guest: (Novabench)
+CPU: 683
+RAM Score: 224
+RAM Speed: 25314 MB/s
+Disk: 288
+Write Speed: 2799 MB/s
+Read Speed: 2403 MB/s 
+GPU: Fails to complete a 6 fps

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ At this point you can start the VM with `virt-manager` or `virsh` directly.
 ### Current benchmarks
 
 Guest: (Novabench)
-CPU: 683
+CPU: 690
 RAM Score: 224
 RAM Speed: 25314 MB/s
 Disk: 288

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ At this point you can start the VM with `virt-manager` or `virsh` directly.
 ### Current benchmarks
 
 Guest: (Novabench)
-CPU: 690
+CPU: 711
 RAM Score: 224
 RAM Speed: 25314 MB/s
 Disk: 288

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You probably also want `virt-manager`, which includes a spice compatible viewer.
 
 1) clone the repository
 2) Create a disk image to use as your primary hard disk for the VM: `qemu-img create -f qcow2 -o size=60G my-vm-disk.img`. For better performance you may consider using `-f raw`, but you will lose features like snapshot, compression, etc.
-2) Edit `win10.xml` and change lines 49-50 with the location and type of your disk image.
+2) Edit `win10.xml` and change lines 49-50 with the location and type of your disk image, and lines 20-29 (`cputune`) and 49 (`topology`) to match the physical topology of your CPU.
 3) Define the XMLs in this repository for libvirt. `virsh define /path/to/this/repo/networks/default.xml` and then `virsh define /path/to/this/repo/win10.xml`.
 
 At this point you can start the VM with `virt-manager` or `virsh` directly.
@@ -27,10 +27,19 @@ At this point you can start the VM with `virt-manager` or `virsh` directly.
 ### Current benchmarks
 
 Guest: (Novabench)
-CPU: 711
+CPU: 917
 RAM Score: 224
 RAM Speed: 25314 MB/s
 Disk: 288
 Write Speed: 2799 MB/s
 Read Speed: 2403 MB/s 
 GPU: Fails to complete a 6 fps
+
+### Performance improvements applied
+
+* Pin vCPUs, IO threads, and emulator thread to physical cores. No difference until you are using majority of your cores for the VM
+* virtio drivers for everything. This especially benefits from pinned IO cores.
+* hyperV opions recommended for speed
+* Raw disk image vs qcow2 (no difference on f2fs)
+* Scaling CPU cores - best to have the majority of your cores assigned to the VM, to ensure the host's CPU frequency governor scales when the VM is under load. I have 6 of 8 cores in the VM.
+* CPU in host-passthrough mode

--- a/win10.xml
+++ b/win10.xml
@@ -33,7 +33,9 @@ or other application using the libvirt API.
     </hyperv>
     <vmport state='off'/>
   </features>
-  <cpu mode='host-model' check='partial'/>
+  <cpu mode='host-passthrough' check='none'>
+    <topology sockets='1' dies='1' cores='2' threads='2'/>
+  </cpu>
   <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>
     <timer name='pit' tickpolicy='delay'/>

--- a/win10.xml
+++ b/win10.xml
@@ -15,6 +15,12 @@ or other application using the libvirt API.
   <memory unit='KiB'>8388608</memory>
   <currentMemory unit='KiB'>8388608</currentMemory>
   <vcpu placement='static'>4</vcpu>
+  <cputune>
+    <vcpupin vcpu='0' cpuset='1'/>
+    <vcpupin vcpu='1' cpuset='2'/>
+    <vcpupin vcpu='2' cpuset='3'/>
+    <vcpupin vcpu='3' cpuset='4'/>
+  </cputune>
   <os>
     <type arch='x86_64' machine='pc-q35-5.2'>hvm</type>
     <bootmenu enable='no'/>
@@ -33,7 +39,7 @@ or other application using the libvirt API.
     </hyperv>
     <vmport state='off'/>
   </features>
-  <cpu mode='host-passthrough' check='none'>
+  <cpu mode='host-passthrough' check='none' migratable='on'>
     <topology sockets='1' dies='1' cores='2' threads='2'/>
   </cpu>
   <clock offset='localtime'>

--- a/win10.xml
+++ b/win10.xml
@@ -14,33 +14,40 @@ or other application using the libvirt API.
   </metadata>
   <memory unit='KiB'>8388608</memory>
   <currentMemory unit='KiB'>8388608</currentMemory>
-  <vcpu placement='static'>4</vcpu>
+  <vcpu placement='static'>6</vcpu>
+  <iothreads>2</iothreads>
   <cputune>
-    <vcpupin vcpu='0' cpuset='1'/>
-    <vcpupin vcpu='1' cpuset='2'/>
-    <vcpupin vcpu='2' cpuset='3'/>
-    <vcpupin vcpu='3' cpuset='4'/>
+    <vcpupin vcpu='0' cpuset='0'/>
+    <vcpupin vcpu='1' cpuset='1'/>
+    <vcpupin vcpu='2' cpuset='2'/>
+    <vcpupin vcpu='3' cpuset='3'/>
+    <vcpupin vcpu='4' cpuset='4'/>
+    <vcpupin vcpu='5' cpuset='5'/>
+    <emulatorpin cpuset='6-7'/>
+    <iothreadpin iothread='1' cpuset='6-7'/>
+    <iothreadpin iothread='2' cpuset='6-7'/>
   </cputune>
   <os>
     <type arch='x86_64' machine='pc-q35-5.2'>hvm</type>
+    <boot dev='hd'/>
     <bootmenu enable='no'/>
   </os>
   <features>
     <acpi/>
     <apic/>
     <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-      <vpindex state="on"/>
-      <synic state="on"/>
-      <stimer state="on"/>
-      <frequencies state="on"/>
+      <relaxed state='on'/>
+      <vapic state='on'/>
+      <spinlocks state='on' retries='8191'/>
+      <vpindex state='on'/>
+      <synic state='on'/>
+      <stimer state='on'/>
+      <frequencies state='on'/>
     </hyperv>
     <vmport state='off'/>
   </features>
   <cpu mode='host-passthrough' check='none' migratable='on'>
-    <topology sockets='1' dies='1' cores='2' threads='2'/>
+    <topology sockets='1' dies='1' cores='3' threads='2'/>
   </cpu>
   <clock offset='localtime'>
     <timer name='rtc' tickpolicy='catchup'/>

--- a/win10.xml
+++ b/win10.xml
@@ -23,9 +23,13 @@ or other application using the libvirt API.
     <acpi/>
     <apic/>
     <hyperv>
-      <relaxed state='on'/>
-      <vapic state='on'/>
-      <spinlocks state='on' retries='8191'/>
+      <relaxed state="on"/>
+      <vapic state="on"/>
+      <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
     </hyperv>
     <vmport state='off'/>
   </features>

--- a/win10.xml
+++ b/win10.xml
@@ -71,10 +71,9 @@ or other application using the libvirt API.
       <address type='drive' controller='0' bus='0' target='0' unit='1'/>
     </disk>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
-      <source file='/home/ohthehugemanatee/Documents/win10.qcow2'/>
+      <driver name='qemu' type='raw' discard='unmap'/>
+      <source file='/home/ohthehugemanatee/Documents/win10.img'/>
       <target dev='vda' bus='virtio'/>
-      <boot order='1'/>
       <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
     </disk>
     <controller type='usb' index='0' model='qemu-xhci' ports='15'>
@@ -156,6 +155,12 @@ or other application using the libvirt API.
     </redirdev>
     <redirdev bus='usb' type='spicevmc'>
       <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='4'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='5'/>
     </redirdev>
     <memballoon model='virtio'>
       <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>

--- a/win10.xml
+++ b/win10.xml
@@ -7,6 +7,7 @@ or other application using the libvirt API.
 
 <domain type='kvm'>
   <name>win10</name>
+  <uuid>8444b085-f0ab-484a-9904-e647293d04f9</uuid>
   <metadata>
     <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
       <libosinfo:os id="http://microsoft.com/win/10"/>

--- a/win10.xml
+++ b/win10.xml
@@ -7,7 +7,6 @@ or other application using the libvirt API.
 
 <domain type='kvm'>
   <name>win10</name>
-  <uuid>8444b085-f0ab-484a-9904-e647293d04f9</uuid>
   <metadata>
     <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
       <libosinfo:os id="http://microsoft.com/win/10"/>


### PR DESCRIPTION
Started adding improvements, performance testing with novabench the whole way. 

* Pin vCPUs, IO threads, and emulator thread to physical cores. No difference until you are using majority of your cores for the VM.
* virtio drivers for everything. This especially benefits from pinned IO cores.
* hyperV opions recommended for speed (closes #1) 
* Raw disk image vs qcow2 (no difference on f2fs, but hypothetically there should be a difference for others)
* Scaling CPU cores - best to have the majority of your cores assigned to the VM... With only half my cores assigned to the VM, even pinning the vCPUs wasn't enough to trigger my host's `intel_pstate` governor to scale CPU frequency appropriately. Ended with 6 of 8 available cores in the VM.
* CPU in host-passthrough mode
